### PR TITLE
Replace osc52 support table with can I use terminal

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,57 +17,7 @@ Refer to link:tty-copy.1.adoc[tty-copy(1)] for usage information.
 
 == Supported Terminals
 
-Here is a non-exhaustive list of the status of popular terminal emulators regarding OSC52 footnote:[This list was originally copied from https://github.com/ojroques/vim-oscyank[vim-oscyank].]:
-
-|===
-| Terminal | OSC 52 support
-
-| https://github.com/alacritty/alacritty[Alacritty]
-| *yes*
-
-| https://github.com/contour-terminal/contour[Contour]
-| *yes*
-
-| https://github.com/elfmz/far2l[far2l]
-| *yes*
-
-| https://codeberg.org/dnkl/foot[foot]
-| *yes*
-
-| https://github.com/GNOME/gnome-terminal[GNOME Terminal] (and other VTE-based terminals)
-| https://bugzilla.gnome.org/show_bug.cgi?id=795774[not yet]
-
-| https://iterm2.com/[iTerm2]
-| *yes*
-
-| https://github.com/kovidgoyal/kitty[kitty]
-| *yes*
-
-| https://konsole.kde.org[Konsole]
-| *yes* (https://bugs.kde.org/show_bug.cgi?id=372116[since 24.12])
-
-| https://github.com/lxqt/qterminal[QTerminal]
-| https://github.com/lxqt/qterminal/issues/839[not yet]
-
-| http://rxvt.sourceforge.net/[rxvt]
-| *yes* (to be confirmed)
-
-| https://www.gnu.org/software/screen/[screen]
-| *yes*
-
-| https://en.wikipedia.org/wiki/Terminal_(macOS)[Terminal.app]
-| no, but see https://github.com/matvore/pb52[workaround]
-
-| https://github.com/tmux/tmux[tmux]
-| *yes*
-
-| http://software.schmorp.de/pkg/rxvt-unicode.html[urxvt]
-| *yes* (with a script, see https://github.com/ojroques/vim-oscyank/issues/4[here])
-
-| https://github.com/microsoft/terminal[Windows Terminal]
-| *yes*
-|===
-
+Here is a non-exhaustive list of the status of popular terminal emulators regarding OSC52: https://can-i-use-terminal.github.io/features/osc52copy.html
 
 == Requirements
 


### PR DESCRIPTION
[Can I use terminal](https://can-i-use-terminal.github.io/) is a site for support tables of terminal emulator features. Seeing this list and some other lists like https://arewesixelyet.rs/ I decided to create this site for better discoverability and collecting all the data in a single place. You can see its osc52 page at https://can-i-use-terminal.github.io/features/osc52copy.html

It includes more terminals than current list, and in addition to that, by merging these parallel lists (another one is [in vim-oscyank](https://github.com/ojroques/vim-oscyank)) in a single place, it can reduce maintenance cost in community and result in higher quality and more up to date data.