### PR TITLE
Add support for compiling both ARM and x86_64 on Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,11 @@ jobs:
       - name: Generate checksums.txt
         run:
           shasum -a 256 * > checksums.txt
-        working-directory: binaries
+        working-directory: dist
 
       - name: Upload binaries to Releases
         uses: softprops/action-gh-release@v1
         with:
-          files: binaries/*
+          files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,13 @@ jobs:
           if-no-files-found: error
 
   build-macos:
-    name: Build on macOS x86_64
+    name: Build on macOS ARM
     runs-on: macos-latest
+    strategy:
+      matrix:
+        ARCH:
+          - x86_64
+          - arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -101,9 +106,9 @@ jobs:
           GIT_TAG=$(git describe --tags --match 'v*' 2>/dev/null || echo ${GITHUB_REF##*/})
           echo "VERSION=${GIT_TAG#v}" >> $GITHUB_ENV
 
-      - name: Build tty-copy
+      - name: Build tty-copy for ${{ matrix.ARCH }}
         run: |
-          make build VERSION="${{ env.VERSION }}"
+          arch -arch ${{ matrix.ARCH }} make build VERSION="${{ env.VERSION }}"
           ls -lah build/
           file build/tty-copy
 
@@ -115,12 +120,12 @@ jobs:
       - name: Rename binary before upload
         run: |
           mkdir dist
-          cp -a build/tty-copy dist/tty-copy.x86_64-darwin
+          cp -a build/tty-copy dist/tty-copy.${{ matrix.ARCH }}-darwin
 
       - name: Upload binary to artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: x86_64-darwin
+          name: ${{ matrix.ARCH }}-darwin
           path: dist/*
           if-no-files-found: error
 


### PR DESCRIPTION
Hey, really nice and handy project! 🙂

I noticed there wasn't an Apple Silicon native build, so I made a couple of changes to allow for Github to compile both x86_64 and ARM versions on MacOS.

The runner `macos-latest` is [actually an ARM one now](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), so by default it would build an ARM executable.

The change I made was just to pass `make` through the `arch` command for each architecture (works due to Apple's `make` being a universal binary, and Rosetta allowing x64_86 to be run on the ARM runner).

I also changed the directory specified in the publish section so it matches those used in the build sections.

All seems to work nicely on my test build - https://github.com/IdyllicHappiness/tty-copy/releases/tag/v0.2.3

Cheers!
IdyllicHappiness